### PR TITLE
Add issue creation link and info to resources page

### DIFF
--- a/src/pages/resources/index.md
+++ b/src/pages/resources/index.md
@@ -1,5 +1,9 @@
 # Resources
 
+:::tip
+The Cloud Robotics Working Group is accepting suggestions for resources to be hosted on this page. If you have a resource that you want to tell the community about, please [create an issue](https://github.com/cloudroboticshub/cloudroboticshub.github.io/issues/new) and one of the group will review the suggestion, and if accepted, add it to the page!
+:::
+
 - [Fog Robotics](https://sites.google.com/view/fogrobotics) Utilize storage, compute, and networking resources between cloud and edge in a federated manner. From UC Berkeley.
   - [FogROS 2](https://berkeleyautomation.github.io/FogROS2/about) An Adaptive and Extensible Platform for Cloud and Fog Robotics Using ROS 2. [Code](https://github.com/BerkeleyAutomation/FogROS2) 
 - [International Conference on Cloud and Robotics](https://www.cloudrobotics.info/) Ongoing academic conference series on cloud and robotics topics. Proceedings are not available at this site.


### PR DESCRIPTION
Adds link to the resources page for creating a Github issue in the repository to suggest resources for the page. Team members can then review the suggestion and add it to the page.