### PR TITLE
Add Zenoh blog post and next meeting announcement

### DIFF
--- a/blog/2024-11-04-julien-enoch-zenoh/index.md
+++ b/blog/2024-11-04-julien-enoch-zenoh/index.md
@@ -1,0 +1,25 @@
+---
+title: "Julien Enoch presents Eclipse Zenoh"
+slug: julien-enoch-zenoh
+authors: michaelhart
+tags: [ros, zenoh, guest]
+---
+
+[Julien Enoch](https://www.linkedin.com/in/julienenoch/), a Senior Solutions Architect at [ZettaScale Technology](https://www.zettascale.tech/) and [Eclipse Zenoh](https://github.com/eclipse-zenoh/zenoh) committer, joined our meeting on 4th November 2024. He gave a talk on Eclipse Zenoh, a protocol which can run everywhere, from micro-controllers to the Cloud; over TCP, UDP, QUIC, and Websockets. Zenoh provides a software router that can be deployed in any Cloud instance such as AWS EC2, and that can route the protocol between different subsystems.
+
+<iframe class="youtube-video" src="https://www.youtube.com/embed/ANBG_O0fQwQ?si=X3zJtsKlXY6e-3HM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<!-- truncate -->
+
+Julien started by talking about how the Zenoh protocol works, including the software router and example network diagrams. Zenoh is written in Rust, is available in many languages, comes with built-in messaging features like fragmentation and batching, and can operate over any data link, including TCP, Serial, Bluetooth, and so on.
+
+Julien showed how fast the protocol can perform compared to other solutions, and how it's possible to extend the protocol using plugins. He also demonstrated using RViz to control a Turtlebot 4 via Zenoh, where one machine was in France and another in California, United States.
+
+The talk then went on to where the protocol could run, how it could discover other nodes, and how to update network configuration without making code changes. This also includes TLS encryption on the link.
+
+Finally, Julien answered questions from the group, including the maturity of JavaScript language support, how multi-router discovery works, and access control options for Zenoh. For more detail on any of these points, watch the recording above for the full talk!
+
+:::info
+The Cloud Robotics Working Group is always on the lookout for more guest speakers. If you have a talk you would like to give or a suggestion of another speaker who may be interested, please [let us know](/meetings)!
+:::
+

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -18,7 +18,7 @@ fogros2:
   label: FogROS2
   permalink: /fogros2
   description: Related to FogROS2, a framework for cloud deployment of computational graphs in a security-conscious manner
-fogros2:
+zenoh:
   label: Eclipse Zenoh
   permalink: /zenoh
   description: Related to Eclipse Zenoh, a messaging protocol with software router provided, capable of working via the cloud

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -18,3 +18,7 @@ fogros2:
   label: FogROS2
   permalink: /fogros2
   description: Related to FogROS2, a framework for cloud deployment of computational graphs in a security-conscious manner
+fogros2:
+  label: Eclipse Zenoh
+  permalink: /zenoh
+  description: Related to Eclipse Zenoh, a messaging protocol with software router provided, capable of working via the cloud

--- a/src/pages/meetings/index.md
+++ b/src/pages/meetings/index.md
@@ -12,11 +12,19 @@ information:
 - <a href="https://drive.google.com/drive/folders/1TkuaU2_9_QdL-u0pftaIGQu6ecTN5Ci1">Google Drive folder</a>, where we keep all of our public documents.
 - <a href="https://calendar.google.com/calendar/u/0/embed?src=c_3fc5c4d6ece9d80d49f136c1dcd54d7f44e1acefdbe87228c92ff268e85e2ea0@group.calendar.google.com&ctz=America/Los_Angeles">Open Robotics Community Calendar</a>, where you can sign up to receive calendar reminders of our meetings.
 
-## 2024-11-04 <mark>Upcoming Guest Talk</mark>: Eclipse Zenoh and its offering for Cloud Connectivity (Julien Enoch)
+## Upcoming Meeting: 2024-11-18
 
-On 2024-11-04 we will host a talk by [Julien Enoch](https://www.linkedin.com/in/julienenoch/), a Senior Solutions Architect at [ZettaScale Technology](https://www.zettascale.tech/) and [Eclipse Zenoh](https://github.com/eclipse-zenoh/zenoh) committer.
+The group plans to meet on Monday 18th November 2024 to discuss the latest robotics news and how well the group is progressing towards its goals. Anyone is welcome to join!
 
-Julien will talk about the Zenoh protocol, which can run everywhere, from micro-controllers to the Cloud; over TCP, UDP, QUIC, and Websockets. Zenoh provides a software router that can be deployed in any Cloud instance such as AWS EC2, and that can route the protocol between different subsystems. This talk will cover how this is particularly helpful for Connectivity in Cloud Robotics.
+## 2024-11-04 Guest Talk: Eclipse Zenoh and its offering for Cloud Connectivity (Julien Enoch)
+
+The group hosted a talk by [Julien Enoch](https://www.linkedin.com/in/julienenoch/), a Senior Solutions Architect at [ZettaScale Technology](https://www.zettascale.tech/) and [Eclipse Zenoh](https://github.com/eclipse-zenoh/zenoh) committer.
+
+Julien spoke about the Zenoh protocol, which can run everywhere, from micro-controllers to the Cloud; over TCP, UDP, QUIC, and Websockets. Zenoh provides a software router that can be deployed in any Cloud instance such as AWS EC2, and that can route the protocol between different subsystems. The talk also covered how this is particularly helpful for Connectivity in Cloud Robotics, with a video demonstration of controlling a robot in California from an RViz instance in France!
+
+If you would like to see the talk, which took the whole meeting time, see the recording below.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ANBG_O0fQwQ?si=X3zJtsKlXY6e-3HM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## 2024-10-21
 


### PR DESCRIPTION
Added Eclipse Zenoh post from Julien Enoch. Includes meeting recording link.
Also added next meeting announcement, which will be a general discussion.