### PR TITLE
Add next meeting and KubeEdge meeting/blog

### DIFF
--- a/blog/2024-12-16-tomoya-fujita-kubeedge/index.md
+++ b/blog/2024-12-16-tomoya-fujita-kubeedge/index.md
@@ -16,7 +16,7 @@ Resources used during the talk:
 - [Some examples to deploy ROS / ROS 2 with Kubernetes](https://github.com/fujitatomoya/ros_k8s)
 - [Next-generation Robotics Platform for Edge/Cloud](https://static.sched.com/hosted_files/colocatedeventsna2024/15/Cilium%2BeBPF-Day-NA_Cilium-with-KubeEdge.v0.pdf)
 
-Tomoya started by talking through the same slides he used for the demo he gave at ROSCon in 2023, about deploying ROS/ROS2 code using Kubernetes. He talked about enabling deploying to fleets of robots and the pain points that comes with it. He also spoke about using Kubernetes to automatically connect robots to cloud resources, such as API servers, as well as auto-scale those cloud resources.
+Tomoya started by talking through the same slides he used for the demo he gave at ROSCon in 2023, about deploying ROS/ROS2 code using Kubernetes. He talked about enabling deploying to fleets of robots and the pain points that come with it. He also spoke about using Kubernetes to automatically connect robots to cloud resources, such as API servers, as well as auto-scale those cloud resources.
 
 Next, Tomoya spoke about KubeEdge, which is built on Kubernetes and allows networking, application deployment, and metadata synchronization between cloud and edge nodes. KubeEdge can be used to configure ROS2 networks so nodes can talk to each other, and allows a user to interact with a robot fleet via cloud-based API servers, for example.
 

--- a/blog/2024-12-16-tomoya-fujita-kubeedge/index.md
+++ b/blog/2024-12-16-tomoya-fujita-kubeedge/index.md
@@ -1,0 +1,31 @@
+---
+title: "Tomoya Fujita presents Robotics Platforms empowered by Cloud-Native Technologies"
+slug: tomoya-fujita-kubeedge
+authors: michaelhart
+tags: [ros, kubeedge, guest]
+---
+
+[Tomoya Fujita](https://github.com/fujitatomoya), a Software Engineer at Sony, contributor to ROS2 core, and well-respected community builder, joined our meeting on 16th December 2024. He spoke about using Cloud-Native Technologies to deploy to edge devices and manage their life cycles, secrets, configuration, and even secure their network connections.
+
+<iframe class="youtube-video" src="https://www.youtube.com/embed/JBaNNQQxq9c?si=SqFSlXxBl-KEo_po" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<!-- truncate -->
+
+Resources used during the talk:
+- [ROSCon 2023: ROS with Kubernetes / KubeEdge](https://roscon.ros.org/2023/talks/ROS_with_KubernetesKubeEdge.pdf)
+- [Some examples to deploy ROS / ROS 2 with Kubernetes](https://github.com/fujitatomoya/ros_k8s)
+- [Next-generation Robotics Platform for Edge/Cloud](https://static.sched.com/hosted_files/colocatedeventsna2024/15/Cilium%2BeBPF-Day-NA_Cilium-with-KubeEdge.v0.pdf)
+
+Tomoya started by talking through the same slides he used for the demo he gave at ROSCon in 2023, about deploying ROS/ROS2 code using Kubernetes. He talked about enabling deploying to fleets of robots and the pain points that comes with it. He also spoke about using Kubernetes to automatically connect robots to cloud resources, such as API servers, as well as auto-scale those cloud resources.
+
+Next, Tomoya spoke about KubeEdge, which is built on Kubernetes and allows networking, application deployment, and metadata synchronization between cloud and edge nodes. KubeEdge can be used to configure ROS2 networks so nodes can talk to each other, and allows a user to interact with a robot fleet via cloud-based API servers, for example.
+
+He also spoke about securing the data to the application. When any container starts up, KubeEdge can synchronize secrets and configuration to each container. However, this is not done with any effort from the container it self - Tomoya emphasized his belief that applications should be agnostic to their deployment and metadata synchronization mechanism!
+
+After the ROSCon slides, Tomoya spoke about Cilium at the edge via KubeEdge. This is a way to solve the problem of securing cross-network communications, as Cilium modifies the network interfaces of deployed containers to communicate via WireGuard VPN. In this way, nodes on an edge device can communicate with other nodes on other edge devices or in the cloud as if they are on the same network, using encrypted communication. One note is that edge devices need to be on the same physical layer for this to work - the team are working on making edge to edge communication over different networks work as well!
+
+Finally, Tomoya answered questions from the group, including: whether Cilium supports multicast (can be enabled, but is Work In Progress); whether KubeEdge is currently used in production (no, but it's ready); and the configuration for cloud and edge nodes to communicate correctly; among other questions.
+
+:::info
+The Cloud Robotics Working Group is always on the lookout for more guest speakers. If you have a talk you would like to give or a suggestion of another speaker who may be interested, please [let us know](/meetings)!
+:::

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -26,3 +26,7 @@ turtlebot:
   label: Turtlebot Platform
   permalink: /turtlebot
   description: Related to Turtlebot reference platforms, a series of mobile base robots frequently used to demonstrate indoor navigation
+kubeedge:
+  label: KubeEdge
+  permalink: /kubeedge
+  description: Related to KubeEdge, a platform built on Kubernetes that allows deployment of software to edge devices

--- a/src/pages/meetings/index.md
+++ b/src/pages/meetings/index.md
@@ -12,23 +12,29 @@ information:
 - <a href="https://drive.google.com/drive/folders/1TkuaU2_9_QdL-u0pftaIGQu6ecTN5Ci1">Google Drive folder</a>, where we keep all of our public documents.
 - <a href="https://calendar.google.com/calendar/u/0/embed?src=c_3fc5c4d6ece9d80d49f136c1dcd54d7f44e1acefdbe87228c92ff268e85e2ea0@group.calendar.google.com">Open Robotics Community Calendar</a>, where you can sign up to receive calendar reminders of our meetings.
 
-## 2024-12-16 <mark>Upcoming Guest Talk</mark>: Robotics Platform empowered by Cloud-Native Technologies (Tomoya Fujita)
+## 2025-01-13 (Upcoming): General catch-up
 
-On Monday 16th December we will host a talk by [Tomoya Fujita](https://github.com/fujitatomoya),
+The group plans to meet and discuss the latest news in Cloud Robotics. Please come along if you want to catch up with others in the field!
+
+## 2024-12-16 Guest Talk: Robotics Platform empowered by Cloud-Native Technologies (Tomoya Fujita)
+
+In this meeting, we hosted a talk by by [Tomoya Fujita](https://github.com/fujitatomoya),
 a software engineer, contributor to ROS2 core, and well-respected community builder.
 
-Tomoya will talk about a range of Cloud-Native Technologies he has worked on, and their
+Tomoya talked about a range of Cloud-Native Technologies he has worked on, and their
 relevance to robotics. In particular, Tomoya has done a great deal of work on KubeEdge,
 a platform built on Kubernetes that can be used to deploy software to robots as if they
-are Kubernetes clusters. Some resources from his talk includes:
+are Kubernetes clusters. Some resources from his talk include:
 
 - [ROSCon 2023: ROS with Kubernetes / KubeEdge](https://roscon.ros.org/2023/talks/ROS_with_KubernetesKubeEdge.pdf)
 - [Some examples to deploy ROS / ROS 2 with Kubernetes](https://github.com/fujitatomoya/ros_k8s)
 - [Next-generation Robotics Platform for Edge/Cloud](https://static.sched.com/hosted_files/colocatedeventsna2024/15/Cilium%2BeBPF-Day-NA_Cilium-with-KubeEdge.v0.pdf)
 
-Tomoya also plans to leave time to discuss Cloud Robotics with the group, particularly the problems that people are having with Cloud Robotics.
+More information on the talk is available on the [blog post](/blog/tomoya-fujita-kubeedge), including a link to the recording posted on YouTube.
 
-If you are interested in seeing the talk, be sure to join on Monday 16th December from 1700-1800 UTC! The talk will also be recorded and uploaded to YouTube.
+If you are interested in seeing the entire meeting, the recording is available here:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/n-yn4ZKM5cQ?si=SX-fmVyN_LRUvcXV" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## 2024-12-02 | Testing Eclipse Zenoh
 


### PR DESCRIPTION
Adds next meeting entry for Jan 13th.

Also adds Meetings page entry for Tomoya Fujita's talk and a blog post with more information about the talk. Both the meeting and the blog post link to YouTube videos.
