### PR TITLE
Add guide priority and meeting announcements

### DIFF
--- a/blog/2025-05-27-community-guide-priorities/index.md
+++ b/blog/2025-05-27-community-guide-priorities/index.md
@@ -1,0 +1,38 @@
+---
+title: "The Priority List of the Cloud Robotics Hub Guides"
+slug: community-guide-priorities
+authors: michaelhart
+tags: [community]
+---
+
+This is a brief post to announce the results of the community poll to determine priorities of the Cloud Robotics Hub guides.
+
+The polls were posted on:
+
+- ROS Discourse: [Poll Post](https://discourse.ros.org/t/vote-for-the-most-useful-cloud-robotics-guides/43842)
+- LinkedIn: [Poll Post](https://www.linkedin.com/posts/michael-hart-a7614262_vote-for-the-most-useful-cloud-robotics-activity-7330529697442725888-6goD)
+
+After a week of poll time, the results were collected together and combined, assuming that no voter voted in both polls. The results are as follows:
+
+1. Logging and Observability (10 votes)
+    - ROS Discourse: 5 votes
+    - LinkedIn: 5 votes
+1. Simulation on Cloud/Edge (7 votes)
+	- ROS Discourse: 2 votes
+	- LinkedIn: 5 votes
+1. CI/CD/Remote Deployment (7 votes)
+	- ROS Discourse: 5 votes
+	- LinkedIn: 2 votes
+1. Setting up ML in the Cloud (4 votes)
+	- ROS Discourse: 2 votes
+	- LinkedIn: 2 votes
+
+Therefore, the priority list for the group is now:
+
+-  [Priority 1] Uploading Data to the Cloud (Work In Progress)
+-  [Priority 2] Logging and Observability
+-  [Priority 3] Simulation on Cloud/Edge
+-  [Priority 3] CI/CD/Remote Deployment
+-  [Priority 4] Setting up ML in the Cloud
+
+The group will begin to have discussion sessions on each topic to gather information for a guide. We will also consider guests to invite and questions that we need to answer in order to build the guide correctly. With specialist input, we should be able to produce something very valuable for the community.

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -30,3 +30,7 @@ kubeedge:
   label: KubeEdge
   permalink: /kubeedge
   description: Related to KubeEdge, a platform built on Kubernetes that allows deployment of software to edge devices
+community:
+  label: Community
+  permalink: /community
+  description: Related to the community, including any work to be published for the benefit of the community

--- a/src/pages/meetings/index.md
+++ b/src/pages/meetings/index.md
@@ -38,7 +38,7 @@ Cloud Robotics Hub. This would make our expertise available to the
 public in an easily digestible format.
 
 As part of the meeting, we agreed to post a poll to the community to get a
-better idea of priority on each suggested topic. The results are in [this blog post](community-guide-priorities).
+better idea of priority on each suggested topic. The results are in [this blog post](/blog/community-guide-priorities).
 
 If you would like to see the meeting recording, it is available on YouTube:
 

--- a/src/pages/meetings/index.md
+++ b/src/pages/meetings/index.md
@@ -16,19 +16,33 @@ If you have an interesting topic of discussion for the group, please propose
 that topic using the [Github
 Issue](https://github.com/cloudroboticshub/cloudroboticshub.github.io/issues/33).
 
-## 2025-05-19: Ideas for Cloud Robotics Guides (Upcoming)
+## 2025-06-02: Logging and Observability Preparation (Upcoming)
 
-**Note that the time for this meeting and future meetings has changed from
-1700-1800 UTC to 1600-1700 UTC.**
+The group plans to build up the knowledge for a community guide on Logging and
+Observability in Cloud Robotics. As part of this meeting, the group will pool
+their knowledge and list questions to ask experts in the field. We will then be
+able to reach out to experts, either questioning them directly, or inviting them
+to talk with the group at a future meeting.
 
-The group plans to meet to discuss writing public guides, made available through
-this site. The guides would be on a range of subjects, starting with uploading
-data to the cloud and using it successfully. The group will discuss other
-possible subjects for the site and categorise them based on how useful they are
-likely to be.
+The guide, once complete, will involve best practices of logging and
+observability, how to set it up, and the kind of value that can be obtained from
+it.
 
-If you are interested in Cloud Robotics, come and have your say in what the most
-helpful guides would be for the whole community.
+If you're interested in logging and/or observability, please come along and give
+your input for the guide.
+
+## 2025-05-19: Ideas for Cloud Robotics Guides
+
+The group met and used this time to discuss possible guides for publishing on
+Cloud Robotics Hub. This would make our expertise available to the
+public in an easily digestible format.
+
+As part of the meeting, we agreed to post a poll to the community to get a
+better idea of priority on each suggested topic. The results are in [this blog post](community-guide-priorities).
+
+If you would like to see the meeting recording, it is available on YouTube:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/vm5-B8y8kn8?si=AWtO1TdwmjQeFao6" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## 2025-05-05: Continued Discussion: Uploading Robot Data to the Cloud
 


### PR DESCRIPTION
This adds a blog post announcing the guide topic priorities and the next meeting, which will be to prepare for a logging and observability discussion. We can give our own inputs for the guide, plus decide who else to ask, and what the most important questions to answer are.
